### PR TITLE
Choose make as compiler (instead of the default)

### DIFF
--- a/ausarbeitung.tex
+++ b/ausarbeitung.tex
@@ -1,4 +1,5 @@
 % !TeX spellcheck = de_DE
+% !TeX program = make
 % Dieses Dokument muss mit PDFLatex gesetzt werden
 % Vorteil: Grafiken koennen als jpg, png, ... verwendet werden
 %          und die Links im Dokument sind auch gleich richtig


### PR DESCRIPTION
This change overrides the compile command to use `make` for some common IDEs (such as TeXStudio).