### PR TITLE
Fix non-inline todos and tweaks to todo package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# 1.2.0 - to be released
+
+### Changed
+- Fixed non-inline todos
+- Use German name for 'list of todos' in German thesis
+
 ## 1.1.0 - 2017-07-22
 
 ### Changed

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -796,7 +796,11 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 
 %%%
 %schoene TODOs
+\ifdeutsch
+\usepackage[ngerman]{todonotes}
+\else
 \usepackage{todonotes}
+\fi
 \setlength{\marginparwidth}{2,5cm}
 
 \let\xtodo\todo

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -797,9 +797,9 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 %schoene TODOs
 \ifdeutsch
-\usepackage[ngerman]{todonotes}
+\usepackage[colorinlistoftodos,ngerman]{todonotes}
 \else
-\usepackage{todonotes}
+\usepackage[colorinlistoftodos]{todonotes}
 \fi
 \setlength{\marginparwidth}{2,5cm}
 

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -433,17 +433,6 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 
 
 %%%
-%schoene TODOs
-\usepackage{todonotes}
-\let\xtodo\todo
-\renewcommand{\todo}[1]{\xtodo[inline,color=black!5]{#1}}
-\newcommand{\utodo}[1]{\xtodo[inline,color=green!5]{#1}}
-\newcommand{\itodo}[1]{\xtodo[inline]{#1}}
-%
-%%%
-
-
-%%%
 %biblatex statt bibtex
 \usepackage[
   backend       = biber, %biber does not work with 64x versions alternative: bibtex8
@@ -802,6 +791,19 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
   includehead,
   includefoot
 ]{geometry}
+%%%
+
+
+%%%
+%schoene TODOs
+\usepackage{todonotes}
+\setlength{\marginparwidth}{2,5cm}
+
+\let\xtodo\todo
+\renewcommand{\todo}[1]{\xtodo[inline,color=black!5]{#1}}
+\newcommand{\utodo}[1]{\xtodo[inline,color=green!5]{#1}}
+\newcommand{\itodo}[1]{\xtodo[inline]{#1}}
+%
 %%%
 
 %%%

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -830,3 +830,4 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 \usepackage{tikz}
 }{}
 %%%
+


### PR DESCRIPTION
- Since the last release non-inline todos were broken. I fixed this in a427b46. The todo package has to be loaded after geometry (see http://ftp.math.purdue.edu/mirrors/ctan.org/macros/latex/contrib/todonotes/todonotes.pdf)
- The name of the 'List of Todos' depends now on the thesis language
- Also colors are displayed in the 'List of Todos'

Regards

- [x] Change in CHANGELOG.md described
