### PR TITLE
Fix translation of float name of "Algorithmus" and "algorithm" environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Changed
+
+- Translate float name of 'Algorithmus' environment in English thesis
+- Translate float name of 'algorithm' environment only in German thesis
+
 ## [1.2.0] - 2017-07-28
 
 ### Changed

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -721,9 +721,9 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 
 
 %%%
-%fuer algorithm.sty: - falls Deutsch und nicht Englisch. Falls Englisch als Sprache gewählt wurde, bitte die folgenden beiden Zeilen auskommentieren.
-\floatname{algorithm}{Algorithmus}
+%fuer algorithm.sty: - falls Deutsch und nicht Englisch.
 \ifdeutsch
+\floatname{algorithm}{Algorithmus}
 \renewcommand{\listalgorithmname}{Verzeichnis der Algorithmen}
 \fi
 %

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -656,6 +656,7 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 \crefname{Algorithmus}{Algorithmus}{Algorithmus}
 \else
 \crefname{Algorithmus}{Algorithm}{Algorithms}
+\floatname{Algorithmus}{Algorithm}
 \fi
 %
 %amsmath


### PR DESCRIPTION
Translate the float name of the "Algorithmus" environment if english is selected as language (fixes #60) and translate the float name of the "algorithm" environment only if german is selected as language.

- [x] Change in CHANGELOG.md described
