### PR TITLE
Update biblatex options to break long lines

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -458,6 +458,10 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
   doi           = true,
   isbn          = true,
   backref       = true]{biblatex}
+  
+\setcounter{biburllcpenalty}{7000}
+\setcounter{biburlucpenalty}{8000}
+  
 \bibliography{bibliography}
 %\addbibresource[datatype=bibtex]{bibliography.bib}
 


### PR DESCRIPTION
This enables line breaks in long urls which are not separated by spaces or slashes
Prevens that the URLs run in the margin
https://tex.stackexchange.com/a/134281

<...describe the change...>

- [ ] Change in CHANGELOG.md described
