### PR TITLE
Add colortbl to enable colored cells in tables

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -75,6 +75,7 @@
 % EN: Defintion of colors
 % DE: Farbdefinitionen
 \usepackage[hyperref,dvipsnames]{xcolor}
+\usepackage{colortbl} %enables the use of color for rows/cols/cells in tablse
 %
 
 %%%


### PR DESCRIPTION
Colortbl allows the usage of \cellolor in tables. Works with booktabs. 
https://texblog.org/2017/12/12/color-table-series-part-1-introduction-colortbl-package/

<...describe the change...>

- [ ] Change in CHANGELOG.md described
