### PR TITLE
Minor general fies to get acquainted with the repository

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -143,8 +143,10 @@
 %%%
 % EN: For easy quotations: \enquote{text}
 %     This package is very smart when nesting is applied, otherwise textcmds (see below) provides a shorter command
-% DE:  Anführungszeichen
-%      Zitate in \enquote{...} setzen, dann werden automatisch die richtigen Anführungszeichen verwendet.
+%     Note that this package results in a warning when it is loaded before minted (actually fvextra).
+% DE: Anführungszeichen
+%     Zitate in \enquote{...} setzen, dann werden automatisch die richtigen Anführungszeichen verwendet.
+%     Dieses package erzeugt eine Warnung, wenn es vor minted (genauer fvextra) geladen wird.
 \usepackage{csquotes}
 %%%
 

--- a/docs/adr/0003-use-minted-for-code-highlithing.md
+++ b/docs/adr/0003-use-minted-for-code-highlithing.md
@@ -6,8 +6,8 @@ Source code needs to be highlighted
 ## Considered Options
 
 * [minted](https://www.ctan.org/pkg/minted)
-* [listings](https://www.ctan.org/pkg/minted)
-* [pygmentex](https://www.ctan.org/pkg/pygmentex]
+* [listings](https://www.ctan.org/pkg/listings)
+* [pygmentex](https://www.ctan.org/pkg/pygmentex)
 
 
 ## Decision Outcome


### PR DESCRIPTION
Fixed minor misspelling in adr 0003 resulting in incorrect link rendering for pygmentex.
Fixed incorrect ctan-linkage of listings to minted.
Also adds a bit of documentation on the usepackage for csquotes referring to the results of investigations into fvextra complaining about it.