### PR TITLE
Fix renaming of `\acronymname` when using german

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed loading of "TeX Gyre Termes" and "TeX Gyre Heros" on MiKTeX.
 - Fixed bold and italics
 - Fixed font in math environment `\mathrm` to use "TeX Gyre Termes"
+- Fixed renaming of `\acronymname` to "Abkürzungsverzeichnis" when using the german template
 
 ## Changed
 

--- a/config.tex
+++ b/config.tex
@@ -787,7 +787,10 @@
 % DE: siehe http://www.dickimaw-books.com/cgi-bin/faq.cgi?action=view&categorylabel=glossaries#glsnewwriteexceeded
 \usepackage[acronym,indexonlyfirst,nomain]{glossaries}
 \ifdeutsch
-  \renewcommand*{\acronymname}{Abkürzungsverzeichnis}
+  \addto\captionsngerman % DE: siehe https://tex.stackexchange.com/a/154566
+  {%
+    \renewcommand*{\acronymname}{Abkürzungsverzeichnis}
+  }
 \else
   \renewcommand*{\acronymname}{List of Abbreviations}
 \fi


### PR DESCRIPTION
Fixes #116 

- [x] Change in CHANGELOG.md described
