### PR TITLE
For Lua(La)TeX, define missing sans font variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bold and italics
 - Fixed font in math environment `\mathrm` to use "TeX Gyre Termes"
 - Fixed renaming of `\acronymname` to "Abkürzungsverzeichnis" when using the german template
+- Fixed loading of "TeX Gyre Heros" variants on LuaLaTeX
 
 ## Changed
 

--- a/config.tex
+++ b/config.tex
@@ -89,7 +89,11 @@
        ItalicFont     = TeXGyreTermes-Italic ,
        BoldItalicFont = TeXGyreTermes-BoldItalic,
        NFSSFamily     = ntxtlf]
-  \setsansfont[Scale=.9]{TeX Gyre Heros Regular}
+  \setsansfont{TeX Gyre Heros Regular}[
+       Scale=.9,
+       BoldFont       = TeX Gyre Heros Bold,
+       ItalicFont     = TeX Gyre Heros Italic,
+       BoldItalicFont = TeX Gyre Heros BoldItalic]
   \setmonofont[StylisticSet={1,3},Scale=.9]{inconsolata}
   \RequirePackage{newtxmath}
 \else


### PR DESCRIPTION
Fixes latextemplates#123 by adding the other variants to the definition

- [x] Change in CHANGELOG.md described
