### PR TITLE
Fix link to docker image

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ This is provides a perfectly configured latex distribution with all required too
 4. Open TeXstudio
 5. Options > Configure TeXstudio > Commands
 6. Set "LuaLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:/home danteev/texlive lualatex --shell-escape -synctex=1 -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-7. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:/home koppor/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+7. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:/home danteev/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
 8. Check if the "docker pull" command from step 3 succeed. If not, wait.
 9. Try to press the "Compile" (<kbd>F6</kbd>) button in TeXstudio.
 


### PR DESCRIPTION
koopor/texlive is not maintained anymore. danteev/texlive is the maintained version
