### PR TITLE
Replace plantuml setup link with a working link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed font in math environment `\mathrm` to use "TeX Gyre Termes"
 - Fixed renaming of `\acronymname` to "Abkürzungsverzeichnis" when using the german template
 - Fixed loading of "TeX Gyre Heros" variants on LuaLaTeX
+- Fixed the broken PlantUML setup link in the documentation
 
 ### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ If you installed MiKTeX other ways, you have to run "Update MiKTeX (Admin)" and 
     2. Paste and hit <kbd>Enter</kbd> `@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"`
 1. Execute `choco feature enable -n=allowGlobalConfirmation` to get rid off additional installation confirmations.
 1. Execute `choco install texstudio sumatrapdf.install strawberryperl jre8 jabref languagetool` to install necessary tooling.
-1. In case [PlantUML](http://plantuml.com/) should be used, follow the installation instructions at <https://latextemplates.github.io/plantuml/> listed at the "pre-conditions" section.
+1. In case [PlantUML](http://plantuml.com/) should be used, follow the installation instructions at <https://koppor.github.io/plantuml/> listed at the "pre-conditions" section.
 1. For more recommended tooling see <https://github.com/koppor/koppors-chocolatey-scripts>.
 
 ### Recommended setup of MiKTeX


### PR DESCRIPTION
This PR repairs the PlantUML setup link in the docs. 

- [x] Change in CHANGELOG.md described
