### PR TITLE
Fix deprecated siunitx option in config

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -417,10 +417,10 @@
 
 % EN: Enable typesetting values with SI units.
 \ifdeutsch
-  \usepackage[mode=text,group-four-digits]{siunitx}
+  \usepackage[mode=text,group-minimum-digits=4]{siunitx}
   \sisetup{locale=DE}
 \else
-  \usepackage[mode=text,group-four-digits,group-separator={,}]{siunitx}
+  \usepackage[mode=text,group-minimum-digits=4,group-separator={,}]{siunitx}
   \sisetup{locale=US}
 \fi
 


### PR DESCRIPTION
This is a fix for #139.

The _siunitx_ package seems to have deprecated the `group-four-digits` option. There is compatibility code, however that only works if the option is explicitly set by `group-four-digits=true`. Thus, the compilation breaks as described in #139. As the option is mapped to `group-minimum-digits=4` internally, I would use that option in _config.tex_.