### PR TITLE
Fixed docker compilation commands & sync

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,11 +108,11 @@ This is provides a perfectly configured latex distribution with all required too
    Will download approx. 4GB.
 4. Open TeXstudio
 5. Options > Configure TeXstudio > Commands
-6. Set "PdfLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:/home danteev/texlive pdflatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-7. Set "LuaLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:/home danteev/texlive lualatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-8. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:/home danteev/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+6. Set "PdfLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive pdflatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+7. Set "LuaLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive lualatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+8. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
 9. Check if the "docker pull" command from step 3 succeed. If not, wait.
-10. Try to press the "Compile" (<kbd>F6</kbd>) button in TeXstudio.
+11. Try to press the "Compile" (<kbd>F6</kbd>) button in TeXstudio.
 
 ## Installation hints for Windows
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,17 +102,17 @@ Always working solution: Use the [docker image](https://hub.docker.com/r/danteev
 This is provides a perfectly configured latex distribution with all required tools.
 
 1. Execute `sudo visudo` to edit the sudoers file
-2. Add the line `myusername ALL = (root) NOPASSWD: /usr/bin/docker`. Replace `myusername` accordingly. (Source: <https://unix.stackexchange.com/a/13058/18033>)
-3. Execute `sudo docker pull danteev/texlive`.
+1. Add the line `myusername ALL = (root) NOPASSWD: /usr/bin/docker`. Replace `myusername` accordingly. (Source: <https://unix.stackexchange.com/a/13058/18033>)
+1. Execute `sudo docker pull danteev/texlive`.
    This should not ask for any password.
    Will download approx. 4GB.
-4. Open TeXstudio
-5. Options > Configure TeXstudio > Commands
-6. Set "PdfLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive pdflatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-7. Set "LuaLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive lualatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-8. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
-9. Check if the "docker pull" command from step 3 succeed. If not, wait.
-11. Try to press the "Compile" (<kbd>F6</kbd>) button in TeXstudio.
+1. Open TeXstudio
+1. Options > Configure TeXstudio > Commands
+1. Set "PdfLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive pdflatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+1. Set "LuaLaTeX" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive lualatex --shell-escape -synctex=1 -interaction=nonstopmode %.tex`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+1. Set "Biber" to `docker run --rm -v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT danteev/texlive biber %`, replace `DIROFTEXDOCUMENT` by the directory of your latex document. Example: `/home/user/thesis`.
+1. Check if the "docker pull" command from step 3 succeed. If not, wait.
+1. Try to press the "Compile" (<kbd>F6</kbd>) button in TeXstudio.
 
 ## Installation hints for Windows
 


### PR DESCRIPTION
Thanks for the great template :)

I had to update the docker commands to get it running on my computer (Ubuntu 22.04) and I thought I would contribute the changes

The issue is that the previous docker commands mount the contents to `/home` and assumes that all relative paths will also start from home. If this worked in the past, I guess it's because `/home` used to be the default working directory of the `danteev/texlive` docker image. 

**However, this is no longer the case**, if you run the image the default working directory is `/workdir`.

The simplest fix would be to just mount to `/workdir` instead of `/home`, however this would start failing if the default working directory changed in the future.

I tested it and it worked, but the extremely useful Right-click "Go To Source" and "Go To PDF" options were not working. I looked into it and the issue seemed to be that the file paths saved in the sync file (for me `main-english.synctex.gz`) were generated with the absulte paths on docker, which did not correspond to the paths on the host machine and TeXStudio could not create the mapping between LaTeX code & the PDF

In order to fix the syncing, I had to mirror the host path on the docker container and set that as the working directory. So basically go from:
```
-v DIROFTEXDOCUMENT:/home
```
to:
```
-v DIROFTEXDOCUMENT:DIROFTEXDOCUMENT --workdir=DIROFTEXDOCUMENT 
```

It's a bit longer now, but it should be more robust and with syncing support!

I'm not sure how the host path handling works on Windows, but this should work fine for any Linux/Mac OS

Here's a picture of the "Go To Source" functionality (I'm not sure what the actual name for this feature is)
![image](https://user-images.githubusercontent.com/18612100/204748470-b0e7a6a5-eb4c-4423-baa7-975a9aa681ef.png)

