### PR TITLE
Fix \acronymname in English Version

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -797,7 +797,9 @@
     \renewcommand*{\acronymname}{Abkürzungsverzeichnis}
   }
 \else
-  \renewcommand*{\acronymname}{List of Abbreviations}
+  \addto\captionsenglish{%
+    \renewcommand*{\acronymname}{List of Abbreviations}%
+  }
 \fi
 \renewcommand*{\glsgroupskip}{}
 %


### PR DESCRIPTION
The title of the list of abbreviations should be "List of Abbreviations" but shows "Acronyms." To fix this, we add \acronymname to \addto\captionsenglish.