### PR TITLE
Add German Abstract to English Version

### DIFF
--- a/main-english.tex
+++ b/main-english.tex
@@ -84,6 +84,7 @@
 
 \cleardoublepage
 
+%Solely for German courses of study
 \section*{Kurzfassung}
 
 <Kurzfassung der Arbeit>

--- a/main-english.tex
+++ b/main-english.tex
@@ -78,13 +78,15 @@
 
 %Kurzfassung / abstract
 %auch im Stil vom Inhaltsverzeichnis
-\ifdeutsch
-  \section*{Kurzfassung}
-\else
-  \section*{Abstract}
-\fi
+\section*{Abstract}
 
 <Short summary of the thesis>
+
+\cleardoublepage
+
+\section*{Kurzfassung}
+
+<Kurzfassung der Arbeit>
 
 \cleardoublepage
 

--- a/main-german.tex
+++ b/main-german.tex
@@ -79,11 +79,7 @@ enddate={5.\ Januar 2014}  % English: January 5, 2014; ISO: 2014-01-05
 
 %Kurzfassung / abstract
 %auch im Stil vom Inhaltsverzeichnis
-\ifdeutsch
-  \section*{Kurzfassung}
-\else
-  \section*{Abstract}
-\fi
+\section*{Kurzfassung}
 
 <Kurzfassung der Arbeit>
 


### PR DESCRIPTION
Students must submit a German abstract in addition to the English abstract in most of the courses. So, it makes sense to add both abstracts to the template to make this less confusing and uniform for all submissions.