### PR TITLE
Fix typo and license hint

### DIFF
--- a/.github/workflows/build-and-publish-with-latexmk.yml
+++ b/.github/workflows/build-and-publish-with-latexmk.yml
@@ -1,4 +1,4 @@
-name: Build with lualatex (and publish to gh-pages)
+name: Build with latexmk (and publish to gh-pages)
 on:
   push:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed examples in latexhints
+- Fixed typo in latexmk action name
+- Fixed mention of license in README
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [docs/](docs/) or <http://latextemplates.github.io/scientific-thesis-templat
 
 ## License
 
-The license of this work is [CC0](https://creativecommons.org/publicdomain/zero/1.0/), which corresponds to "public domain".
+The license of this work is [0BSD](https://spdx.org/licenses/0BSD.html) which corresponds to "public domain". Any derived work can freely be relicensed and can omit original copyright and license information.
 
 ### Exceptions
 


### PR DESCRIPTION
- Fix display name of latexmk action
- Fix mention of license in README (already changes some while back)
- Add quick summary of allowed relicensing

- [x] Change in CHANGELOG.md described
